### PR TITLE
drop R version requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     )
 Version: 0.1.0
 Description: Create new projects according to the PHI R project structure.
-Depends: R (>= 3.3.0)
+Depends: R (>= 3.2.0)
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true

--- a/R/phiproject.R
+++ b/R/phiproject.R
@@ -110,7 +110,7 @@ phiproject <- function(path, author) {
     writeLines("", con = file.path(path, ".Renviron"))
     writeLines("", con = file.path(path, ".Rprofile"))
     writeLines(gitignore, con = file.path(path, ".gitignore"))
-    writeLines(rproj_settings, con = file.path(path, paste0(path, ".Rproj")))
+    writeLines(rproj_settings, con = file.path(path, paste0(basename(path), ".Rproj")))
     writeLines(r_code, con = file.path(path, "code", "code.R"))
     writeLines("", con = file.path(path, "code", "functions.R"))
     writeLines("", con = file.path(path, "code", "packages.R"))


### PR DESCRIPTION
plus a small debug - the help example wouldn't run when I ran devtools::check()
This doesn't seem to be a problem when you make the project via the RStudio menu but worth fixing to make the check happy!